### PR TITLE
feat: add GET /orders endpoint with async DB session and N+1 protection

### DIFF
--- a/alembic/versions/94173e165ec5_add_order_status_and_closed_at.py
+++ b/alembic/versions/94173e165ec5_add_order_status_and_closed_at.py
@@ -1,0 +1,29 @@
+"""add order status and closed_at
+
+Revision ID: 94173e165ec5
+Revises: initial_models
+Create Date: 2025-09-24 21:19:01.139586
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '94173e165ec5'
+down_revision: Union[str, Sequence[str], None] = 'initial_models'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema: add status and closed_at to orders."""
+    op.add_column('orders', sa.Column('status', sa.String(length=20), nullable=False, server_default='pending'))
+    op.add_column('orders', sa.Column('closed_at', sa.DateTime(timezone=True), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema: remove status and closed_at from orders."""
+    op.drop_column('orders', 'closed_at')
+    op.drop_column('orders', 'status')

--- a/src/mini_erp_cafe/api/routes/orders.py
+++ b/src/mini_erp_cafe/api/routes/orders.py
@@ -1,0 +1,19 @@
+from typing import List
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from mini_erp_cafe.schemas.order import OrderRead
+from mini_erp_cafe.crud.order import get_orders
+from mini_erp_cafe.db.session import get_async_session
+
+
+router = APIRouter(prefix="/orders", tags=["orders"])
+
+
+@router.get("/", response_model=List[OrderRead])
+async def list_orders(db: AsyncSession = Depends(get_async_session)):
+    """
+    Возвращает список всех заказов с позициями.
+    """
+    orders = await get_orders(db)
+    return orders

--- a/src/mini_erp_cafe/crud/order.py
+++ b/src/mini_erp_cafe/crud/order.py
@@ -1,0 +1,23 @@
+from typing import List
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from mini_erp_cafe.models import Order, OrderItem, MenuItem
+
+
+async def get_orders(db: AsyncSession) -> List[Order]:
+    """
+    Возвращает все заказы, подгружая items и связанные menu_item (чтобы избежать N+1).
+    Сортируем по времени создания (сначала новые).
+    """
+    stmt = (
+        select(Order)
+        .options(
+            selectinload(Order.items).selectinload(OrderItem.menu_item)
+        )
+        .order_by(Order.created_at.desc())
+    )
+    result = await db.execute(stmt)
+    orders = result.scalars().unique().all()
+    return orders

--- a/src/mini_erp_cafe/db/session.py
+++ b/src/mini_erp_cafe/db/session.py
@@ -1,25 +1,26 @@
-# src/mini_erp_cafe/db/session.py
-
-import asyncio
-from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
-from sqlalchemy.orm import declarative_base
-# src/mini_erp_cafe/db/session.py
+from typing import AsyncGenerator
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
 from sqlalchemy.orm import declarative_base
 from mini_erp_cafe.config import settings
 
-# База для моделей
+# Base для моделей
 Base = declarative_base()
 
 # Асинхронный движок
 engine = create_async_engine(settings.DATABASE_URL, echo=True, future=True)
 
-# Создание сессии
+# Фабрика сессий
 AsyncSessionLocal = async_sessionmaker(
     bind=engine,
     class_=AsyncSession,
-    expire_on_commit=False,  # данные не будут "исчезать" после commit
+    expire_on_commit=False,
 )
 
-
-# async_session = AsyncSessionLocal
+# Зависимость для FastAPI
+async def get_async_session() -> AsyncGenerator[AsyncSession, None]:
+    """
+    Использовать в Depends(get_async_session)
+    Пример: async def endpoint(db: AsyncSession = Depends(get_async_session))
+    """
+    async with AsyncSessionLocal() as session:
+        yield session

--- a/src/mini_erp_cafe/main.py
+++ b/src/mini_erp_cafe/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from .api import health, users
+from mini_erp_cafe.api.routes.orders import router as orders_router
 
 app = FastAPI(title="Mini ERP Cafe")
 
@@ -15,6 +16,7 @@ async def on_startup():
 async def on_shutdown():
     print("🛑 Application stopped")
 
+app.include_router(orders_router)
 
 # @asynccontextmanager
 # async def lifespan(app: FastAPI):

--- a/src/mini_erp_cafe/schemas/order.py
+++ b/src/mini_erp_cafe/schemas/order.py
@@ -1,0 +1,27 @@
+from pydantic import BaseModel
+from typing import List, Optional
+from datetime import datetime
+from decimal import Decimal
+
+
+class OrderItemRead(BaseModel):
+    id: int
+    menu_item_id: int
+    quantity: int
+    price: Decimal
+    menu_item_name: Optional[str] = None  # удобство для фронта
+
+    class Config:
+        orm_mode = True
+
+
+class OrderRead(BaseModel):
+    id: int
+    user_id: int
+    status: str
+    created_at: datetime
+    closed_at: Optional[datetime] = None
+    items: List[OrderItemRead] = []
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
Реализована ручка GET /orders
Возвращает список всех заказов с полями id, user_id, status, created_at, closed_at
Используется асинхронная сессия SQLAlchemy
Добавлено предотвращение N+1 проблем через selectinload при необходимости
