### PR TITLE
feat: add DELETE /orders/{order_id} endpoint

### DIFF
--- a/src/mini_erp_cafe/api/routes/orders.py
+++ b/src/mini_erp_cafe/api/routes/orders.py
@@ -10,6 +10,7 @@ from mini_erp_cafe.models.order import Order
 from mini_erp_cafe.models.order_item import OrderItem
 from mini_erp_cafe.schemas.order import OrderCreate, OrderRead
 
+from mini_erp_cafe.crud.order import delete_order
 
 router = APIRouter(prefix="/orders", tags=["orders"])
 
@@ -56,3 +57,13 @@ async def create_order_endpoint(order_in: OrderCreate, db: AsyncSession = Depend
     """
     order = await create_order(db, order_in)
     return order
+
+
+@router.delete("/{order_id}", status_code=204)
+async def remove_order(order_id: int, session: AsyncSession = Depends(get_async_session)):
+    """
+    Удаляет заказ.
+    """
+    deleted = await delete_order(session, order_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Order not found")

--- a/src/mini_erp_cafe/crud/order.py
+++ b/src/mini_erp_cafe/crud/order.py
@@ -76,3 +76,15 @@ async def create_order(db: AsyncSession, order_in: OrderCreate) -> OrderRead:
 
     # возвращаем через Pydantic с menu_item_name
     return OrderRead.from_orm_with_name(order)
+
+
+async def delete_order(session: AsyncSession, order_id: int) -> bool:
+    """
+    Удаляет заказ.
+    """
+    order = await session.get(Order, order_id)
+    if not order:
+        return False
+    await session.delete(order)
+    await session.commit()
+    return True


### PR DESCRIPTION
- добавлен роут удаления заказа
- реализована сервисная функция delete_order
- возвращает 204 No Content при успешном удалении
- выбрасывает 404 если заказ не найден