### PR TITLE
feat: add PATCH /orders/{id} endpoint with safe updates

### DIFF
--- a/src/mini_erp_cafe/api/routes/orders.py
+++ b/src/mini_erp_cafe/api/routes/orders.py
@@ -4,13 +4,13 @@ from fastapi import APIRouter, Depends, HTTPException, Path
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from mini_erp_cafe.crud.order import create_order, get_orders, get_order_by_id
+from mini_erp_cafe.crud.order import update_order, delete_order
 from mini_erp_cafe.db.session import get_async_session
 from mini_erp_cafe.models.menu_item import MenuItem
 from mini_erp_cafe.models.order import Order
 from mini_erp_cafe.models.order_item import OrderItem
-from mini_erp_cafe.schemas.order import OrderCreate, OrderRead
+from mini_erp_cafe.schemas.order import OrderCreate, OrderRead, OrderUpdate
 
-from mini_erp_cafe.crud.order import delete_order
 
 router = APIRouter(prefix="/orders", tags=["orders"])
 
@@ -56,6 +56,27 @@ async def create_order_endpoint(order_in: OrderCreate, db: AsyncSession = Depend
     Возвращает созданный заказ.
     """
     order = await create_order(db, order_in)
+    return order
+
+
+@router.patch("/{order_id}", response_model=OrderRead)
+async def patch_order_endpoint(
+    order_id: int,
+    order_in: OrderUpdate,
+    db: AsyncSession = Depends(get_async_session),
+):
+    """
+    Частичное обновление заказа.
+    Поддерживаемые поля: menu_item_id, quantity, status, special_requests, scheduled_at.
+    """
+    try:
+        order = await update_order(db, order_id, order_in)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    if not order:
+        raise HTTPException(status_code=404, detail="Order not found")
+
     return order
 
 

--- a/src/mini_erp_cafe/crud/order.py
+++ b/src/mini_erp_cafe/crud/order.py
@@ -4,7 +4,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
 from mini_erp_cafe.models import Order, OrderItem, MenuItem
-from mini_erp_cafe.schemas.order import OrderCreate, OrderRead
+from mini_erp_cafe.schemas.order import OrderCreate, OrderRead, OrderUpdate
 
 
 async def get_orders(db: AsyncSession) -> List[Order]:
@@ -75,6 +75,54 @@ async def create_order(db: AsyncSession, order_in: OrderCreate) -> OrderRead:
     order = result.scalars().unique().first()
 
     # возвращаем через Pydantic с menu_item_name
+    return OrderRead.from_orm_with_name(order)
+
+
+VALID_STATUSES = {"open", "in_progress", "done", "cancelled"}
+
+async def update_order(db: AsyncSession, order_id: int, order_in: OrderUpdate) -> OrderRead:
+    """
+    Обновляет заказ.
+    """
+    order = await db.get(Order, order_id)
+    if not order:
+        raise ValueError(f"Order with id={order_id} not found")
+
+    update_data = order_in.dict(exclude_unset=True)
+
+    # Обновление menu_item_id
+    if "menu_item_id" in update_data:
+        menu_item_id = update_data["menu_item_id"]
+        menu_item = await db.get(MenuItem, menu_item_id)
+        if not menu_item:
+            raise ValueError(f"Menu item with id={menu_item_id} not found")
+        order.menu_item_id = menu_item.id
+
+    # Обновление статуса
+    if "status" in update_data:
+        status = update_data["status"]
+        if status not in VALID_STATUSES:
+            raise ValueError(f"Invalid status: {status}")
+        order.status = status
+
+    # Остальные поля
+    for key, value in update_data.items():
+        if key in {"menu_item_id", "status"}:
+            continue
+        setattr(order, key, value)
+
+    await db.commit()
+
+    # Явная загрузка items + menu_item, чтобы не было lazy load
+    result = await db.execute(
+        select(Order)
+        .options(
+            selectinload(Order.items).selectinload(OrderItem.menu_item)
+        )
+        .where(Order.id == order.id)
+    )
+    order = result.scalar_one()
+
     return OrderRead.from_orm_with_name(order)
 
 

--- a/src/mini_erp_cafe/schemas/order.py
+++ b/src/mini_erp_cafe/schemas/order.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, conint
 from typing import List, Optional
 from datetime import datetime
 from decimal import Decimal
@@ -23,6 +23,7 @@ class OrderItemRead(BaseModel):
     class Config:
         from_attributes = True
 
+
 class OrderRead(BaseModel):
     id: int
     user_id: int
@@ -45,11 +46,24 @@ class OrderRead(BaseModel):
     class Config:
         from_attributes = True
 
+
 class OrderItemCreate(BaseModel):
     menu_item_id: int
     quantity: int
     price: Decimal
 
+
 class OrderCreate(BaseModel):
     user_id: int
     items: List[OrderItemCreate]
+
+
+class OrderUpdate(BaseModel):
+    menu_item_id: Optional[int] = None
+    quantity: Optional[conint(ge=1)] = None
+    status: Optional[str] = None  # убрали Enum → строка
+    special_requests: Optional[str] = None
+    scheduled_at: Optional[datetime] = None
+
+    class Config:
+        extra = "forbid"


### PR DESCRIPTION
Этот патч добавляет полноценный PATCH-эндпоинт для заказов:

- Проверка валидного статуса (`open`, `in_progress`, `done`, `cancelled`)
- Обновление menu_item_id с проверкой существования меню
- Безопасная сериализация OrderRead с подгрузкой всех связанных items и menu_item
- Избегает ошибок lazy load и MissingGreenlet
