### PR TITLE
feat: add status filter to GET /orders

### DIFF
--- a/src/mini_erp_cafe/api/routes/orders.py
+++ b/src/mini_erp_cafe/api/routes/orders.py
@@ -1,6 +1,6 @@
-from typing import List
+from typing import List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Path
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from mini_erp_cafe.crud.order import create_order, get_orders, get_order_by_id
@@ -15,19 +15,16 @@ from mini_erp_cafe.schemas.order import OrderCreate, OrderRead, OrderUpdate
 router = APIRouter(prefix="/orders", tags=["orders"])
 
 @router.get("/", response_model=List[OrderRead])
-async def list_orders(db: AsyncSession = Depends(get_async_session)):
+async def list_orders(
+    status: Optional[str] = Query(None, description="Фильтрация по статусу заказа"),
+    db: AsyncSession = Depends(get_async_session)
+):
     """
-    Возвращает список всех заказов с позициями.
+    Возвращает список заказов (новые сверху).
+    Поддерживается фильтрация по статусу: open, in_progress, done, cancelled.
     """
-    orders = await get_orders(db)
-
-    # Дополняем menu_item_name для фронта (это поле есть в схеме)
-    for order in orders:
-        for item in order.items:
-            if getattr(item, "menu_item", None):
-                setattr(item, "menu_item_name", item.menu_item.name)
-
-    return orders
+    orders = await get_orders(db, status=status)
+    return [OrderRead.from_orm_with_name(o) for o in orders]
 
 
 @router.get("/{order_id}", response_model=OrderRead)

--- a/src/mini_erp_cafe/crud/order.py
+++ b/src/mini_erp_cafe/crud/order.py
@@ -7,10 +7,11 @@ from mini_erp_cafe.models import Order, OrderItem, MenuItem
 from mini_erp_cafe.schemas.order import OrderCreate, OrderRead, OrderUpdate
 
 
-async def get_orders(db: AsyncSession) -> List[Order]:
+async def get_orders(db: AsyncSession, status: Optional[str] = None) -> List[Order]:
     """
-    Возвращает все заказы, подгружая items и связанные menu_item (чтобы избежать N+1).
-    Сортируем по времени создания (сначала новые).
+    Возвращает заказы с опциональной фильтрацией по статусу.
+    Подгружаем items и menu_item (чтобы избежать N+1).
+    Сортируем по времени создания (новые сверху).
     """
     stmt = (
         select(Order)
@@ -19,6 +20,9 @@ async def get_orders(db: AsyncSession) -> List[Order]:
         )
         .order_by(Order.created_at.desc())
     )
+    if status:
+        stmt = stmt.where(Order.status == status)
+
     result = await db.execute(stmt)
     orders = result.scalars().unique().all()
     return orders


### PR DESCRIPTION
В существующий эндпоинт GET /orders добавлена поддержка фильтрации по статусу заказа:

- Новый query-параметр `status`
- Поддерживаемые значения: open, in_progress, done, cancelled
- Если параметр не указан — возвращаются все заказы
- Сохраняется сортировка по времени создания (новые сверху)