### PR TITLE
feat: add pagination and filtering for orders list

### DIFF
--- a/src/mini_erp_cafe/api/routes/orders.py
+++ b/src/mini_erp_cafe/api/routes/orders.py
@@ -17,14 +17,17 @@ router = APIRouter(prefix="/orders", tags=["orders"])
 @router.get("/", response_model=List[OrderRead])
 async def list_orders(
     status: Optional[str] = Query(None, description="Фильтрация по статусу заказа"),
-    db: AsyncSession = Depends(get_async_session)
+    limit: int = Query(50, ge=1, le=100, description="Максимум заказов за раз"),
+    offset: int = Query(0, ge=0, description="Смещение для пагинации"),
+    db: AsyncSession = Depends(get_async_session),
 ):
     """
     Возвращает список заказов (новые сверху).
-    Поддерживается фильтрация по статусу: open, in_progress, done, cancelled.
+    Поддерживает фильтрацию по статусу и пагинацию (limit/offset).
     """
-    orders = await get_orders(db, status=status)
+    orders = await get_orders(db, status=status, limit=limit, offset=offset)
     return [OrderRead.from_orm_with_name(o) for o in orders]
+
 
 
 @router.get("/{order_id}", response_model=OrderRead)

--- a/src/mini_erp_cafe/crud/order.py
+++ b/src/mini_erp_cafe/crud/order.py
@@ -7,11 +7,14 @@ from mini_erp_cafe.models import Order, OrderItem, MenuItem
 from mini_erp_cafe.schemas.order import OrderCreate, OrderRead, OrderUpdate
 
 
-async def get_orders(db: AsyncSession, status: Optional[str] = None) -> List[Order]:
+async def get_orders(
+    db: AsyncSession,
+    status: Optional[str] = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> List[Order]:
     """
-    Возвращает заказы с опциональной фильтрацией по статусу.
-    Подгружаем items и menu_item (чтобы избежать N+1).
-    Сортируем по времени создания (новые сверху).
+    Возвращает заказы с фильтрацией и пагинацией.
     """
     stmt = (
         select(Order)
@@ -23,9 +26,12 @@ async def get_orders(db: AsyncSession, status: Optional[str] = None) -> List[Ord
     if status:
         stmt = stmt.where(Order.status == status)
 
+    stmt = stmt.limit(limit).offset(offset)
+
     result = await db.execute(stmt)
     orders = result.scalars().unique().all()
     return orders
+
 
 
 async def get_order_by_id(db: AsyncSession, order_id: int) -> Optional[Order]:


### PR DESCRIPTION
- Добавлена возможность фильтровать список заказов по статусу (status query param).
- Реализована пагинация (limit, offset) для удобного просмотра списка.
- Обновлён сервис и роутер: теперь GET /orders возвращает заказы с учётом фильтров и ограничений.