### PR TITLE
feat: add sorting option to orders list

### DIFF
--- a/src/mini_erp_cafe/api/routes/orders.py
+++ b/src/mini_erp_cafe/api/routes/orders.py
@@ -19,13 +19,14 @@ async def list_orders(
     status: Optional[str] = Query(None, description="Фильтрация по статусу заказа"),
     limit: int = Query(50, ge=1, le=100, description="Максимум заказов за раз"),
     offset: int = Query(0, ge=0, description="Смещение для пагинации"),
+    sort: str = Query("desc", regex="^(asc|desc)$", description="Сортировка: asc или desc"),
     db: AsyncSession = Depends(get_async_session),
 ):
     """
-    Возвращает список заказов (новые сверху).
-    Поддерживает фильтрацию по статусу и пагинацию (limit/offset).
+    Возвращает список заказов.
+    Поддерживает фильтрацию по статусу, пагинацию (limit/offset) и сортировку (asc/desc).
     """
-    orders = await get_orders(db, status=status, limit=limit, offset=offset)
+    orders = await get_orders(db, status=status, limit=limit, offset=offset, sort=sort)
     return [OrderRead.from_orm_with_name(o) for o in orders]
 
 

--- a/src/mini_erp_cafe/crud/order.py
+++ b/src/mini_erp_cafe/crud/order.py
@@ -12,19 +12,26 @@ async def get_orders(
     status: Optional[str] = None,
     limit: int = 50,
     offset: int = 0,
+    sort: str = "desc",
 ) -> List[Order]:
     """
-    Возвращает заказы с фильтрацией и пагинацией.
+    Возвращает заказы с фильтрацией, пагинацией и сортировкой.
     """
     stmt = (
         select(Order)
         .options(
             selectinload(Order.items).selectinload(OrderItem.menu_item)
         )
-        .order_by(Order.created_at.desc())
     )
+
     if status:
         stmt = stmt.where(Order.status == status)
+
+    # сортировка
+    if sort == "asc":
+        stmt = stmt.order_by(Order.created_at.asc())
+    else:
+        stmt = stmt.order_by(Order.created_at.desc())
 
     stmt = stmt.limit(limit).offset(offset)
 


### PR DESCRIPTION
- В эндпоинт GET /orders добавлен новый query-параметр sort (asc | desc).
- По умолчанию сортировка идёт по дате создания — новые заказы сверху (desc).
- Теперь можно комбинировать фильтрацию, пагинацию и сортировку для удобной работы с заказами.