### PR TITLE
feat: add pagination to orders list

### DIFF
--- a/src/mini_erp_cafe/api/routes/orders.py
+++ b/src/mini_erp_cafe/api/routes/orders.py
@@ -20,13 +20,17 @@ async def list_orders(
     status: Optional[str] = Query(None, description="Фильтр по статусу"),
     date_from: Optional[datetime] = Query(None, description="Начальная дата"),
     date_to: Optional[datetime] = Query(None, description="Конечная дата"),
+    limit: Optional[int] = Query(None, description="Количество записей для вывода"),
+    offset: Optional[int] = Query(None, description="Смещение для пагинации"),
     db: AsyncSession = Depends(get_async_session),
 ):
     """
     Возвращает список заказов.
-    Поддерживает фильтрацию по статусу и диапазону дат.
+    Поддерживает фильтрацию по статусу и диапазону дат, фильтрацию и пагинацию.
     """
-    orders = await get_orders(db, status=status, date_from=date_from, date_to=date_to)
+    orders = await get_orders(
+        db, status=status, date_from=date_from, date_to=date_to, limit=limit, offset=offset
+    )
     return [OrderRead.from_orm_with_name(o) for o in orders]
 
 

--- a/src/mini_erp_cafe/crud/order.py
+++ b/src/mini_erp_cafe/crud/order.py
@@ -8,14 +8,17 @@ from mini_erp_cafe.schemas.order import OrderCreate, OrderRead, OrderUpdate
 
 
 async def get_orders(
-    db: AsyncSession,
-    status: Optional[str] = None,
-    date_from: Optional[datetime] = None,
-    date_to: Optional[datetime] = None,
+        db: AsyncSession,
+        status: Optional[str] = None,
+        date_from: Optional[str] = None,
+        date_to: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
 ) -> List[Order]:
     """
     Возвращает список заказов с опциональной фильтрацией по статусу и дате.
     Подгружаем items и menu_item, сортируем по created_at (новые первыми).
+    С фильтрацией и пагинацией.
     """
     stmt = (
         select(Order)
@@ -33,6 +36,11 @@ async def get_orders(
 
     if date_to:
         stmt = stmt.where(Order.created_at <= date_to)
+
+    if limit:
+        stmt = stmt.limit(limit)
+    if offset:
+        stmt = stmt.offset(offset)
 
     result = await db.execute(stmt)
     return result.scalars().unique().all()


### PR DESCRIPTION
В GET /orders добавлены query-параметры:
- limit — количество записей на странице
- offset — смещение (для перехода на следующую страницу)

Работает вместе с фильтрацией и сортировкой.
Улучшает производительность при большом количестве заказов.