### PR TITLE
feat(stats): add order completion time stats endpoint

### DIFF
--- a/src/mini_erp_cafe/api/routes/orders.py
+++ b/src/mini_erp_cafe/api/routes/orders.py
@@ -10,9 +10,8 @@ from mini_erp_cafe.crud.order import get_top_menu_items, get_orders_stats, get_t
 from mini_erp_cafe.crud.order import get_orders_stats_by_user, get_orders_summary_stats
 from mini_erp_cafe.crud.order import get_orders_stats_by_item, get_orders_stats_by_day_and_user
 from mini_erp_cafe.crud.order import get_orders_weekly_stats, get_orders_by_user_stats
-from mini_erp_cafe.crud.order import get_orders_by_item_stats
-from mini_erp_cafe.crud.order import get_orders_by_hour_stats
-from mini_erp_cafe.crud.order import get_orders_by_weekday_stats
+from mini_erp_cafe.crud.order import get_orders_by_item_stats, get_orders_by_hour_stats
+from mini_erp_cafe.crud.order import get_orders_by_weekday_stats, get_order_completion_time_stats
 from mini_erp_cafe.db.session import get_async_session
 from mini_erp_cafe.models.menu_item import MenuItem
 from mini_erp_cafe.models.order import Order, OrderItem
@@ -320,3 +319,15 @@ async def get_orders_by_weekday_stats_endpoint(
     Возвращает статистику заказов по дням недели.
     """
     return await get_orders_by_weekday_stats(db, date_from, date_to)
+
+
+@router.get("/stats/time-to-complete")
+async def get_order_completion_time_stats_endpoint(
+    db: AsyncSession = Depends(get_async_session),
+    date_from: Optional[datetime] = Query(None, description="Начальная дата диапазона"),
+    date_to: Optional[datetime] = Query(None, description="Конечная дата диапазона"),
+):
+    """
+    Возвращает статистику по времени выполнения заказов (от создания до завершения).
+    """
+    return await get_order_completion_time_stats(db, date_from, date_to)


### PR DESCRIPTION
Добавлен новый аналитический эндпоинт: GET /orders/stats/time-to-complete

Что делает:
- Возвращает статистику по времени выполнения заказов (closed_at - created_at):
  - avg_time, min_time, max_time (в формате "Xm Ys")
  - count_orders — количество завершённых заказов в выборке
  - period: from / to (ISO)
- Параметры: date_from, date_to (опционально). По умолчанию — последние 30 дней.
- Если завершённых заказов в периоде нет — возвращается понятное сообщение.

- Быстрая метрика для мониторинга производительности кухни / SLAs.
- Лёгкая реализация, не меняет модели и существующие ручки.